### PR TITLE
Correct order of arguments

### DIFF
--- a/azcopy_wrapper/azcopy_client.py
+++ b/azcopy_wrapper/azcopy_client.py
@@ -47,7 +47,7 @@ class AzClient:
         transfer_options: AzCopyOptions,
     ) -> AzCopyJobInfo:
         """
-        Copies that data from source to destionation
+        Copies that data from source to destination
         with the transfer options specified
         """
         import re
@@ -277,8 +277,8 @@ class AzClient:
 
     def upload_data_to_remote_location(
         self,
-        src: AzRemoteSASLocation,
-        dest: AzLocalLocation,
+        src: AzLocalLocation,
+        dest: AzRemoteSASLocation,
         transfer_options: AzCopyOptions,
     ) -> AzCopyJobInfo:
         return self._copy(src=src, dest=dest, transfer_options=transfer_options)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 setup(
     name="azcopy_wrapper",
-    version="1.0.0",
+    version="1.0.1",
     description=("A simple AzCopy wrapper to transfer data"),
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
The source and destination arguments were the wrong way round for the Azcopy local -> remote copy function.